### PR TITLE
feat : remove dependency from bower

### DIFF
--- a/app/templates/_gulpfile.js
+++ b/app/templates/_gulpfile.js
@@ -23,7 +23,7 @@ paths = {
   assets: 'src/assets/**/*',
   css:    'src/css/*.css',
   libs:   [
-    './src/bower_components/phaser-official/build/phaser.js'
+    './node_modules/phaser/dist/phaser.js'
   ],
   js:     ['src/js/*.js', 'src/js/**/*.js'],
   entry: './src/js/main.js',

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -28,11 +28,11 @@
     "gulp-streamify": "*",
     "watchify": "*",
     "gulp-if": "*",
-    "vinyl-paths": "*"
+    "vinyl-paths": "*",
+    "phaser": "*"
   },
 
   "scripts": {
-    "post-install": "node ./node_modules/bower/bin/bower install",
     "start": "node ./node_modules/gulp/bin/gulp.js",
     "build": "node ./node_modules/gulp/bin/gulp.js build"
   }


### PR DESCRIPTION
I found this issue when trying to use the generator without having bower pre-installed. I first thought to add bower to package.json but then saw it's only use is to download Phaser which already has an npm package published. 

This PR removes the need to have bower installed and the post-install script execution